### PR TITLE
feat: Prefix userIDs and entire channel context options

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Or run local models with:
 | **max_messages** | The maximum number of messages allowed in a reply chain. When exceeded, the oldest messages are dropped. (Default: `25`) |
 | **use_plain_responses** | When set to `true` the bot will use plaintext responses instead of embeds. Plaintext responses have a shorter character limit so the bot's messages may split more often. (Default: `false`)<br /><br />**Also disables streamed responses and warning messages.** |
 | **allow_dms** | Set to `false` to disable direct message access. (Default: `true`) |
+| **use_channel_context** | When set to `true`, the bot uses all messages in the channel for context, not the reply chain. (Default: `false`) |
+| **prefix_with_user_id** | When set to `true`, the bot prepends the Discord user ID to each user‑role message in the format: `"<user_id>: <message content>"`. This is only applied if the selected LLM provider does **not** support the `name` field (i.e., it isn’t listed in `PROVIDERS_SUPPORTING_USERNAMES`). (Default: `false`) |
 | **permissions** | Configure access permissions for `users`, `roles` and `channels`, each with a list of `allowed_ids` and `blocked_ids`.<br /><br />Control which `users` are admins with `admin_ids`. Admins can change the model with `/model` and DM the bot even if `allow_dms` is `false`.<br /><br />**Leave `allowed_ids` empty to allow ALL in that category.**<br /><br />**Role and channel permissions do not affect DMs.**<br /><br />**You can use [category](https://support.discord.com/hc/en-us/articles/115001580171-Channel-Categories-101) IDs to control channel permissions in groups.** |
 
 ### LLM settings:

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -10,6 +10,8 @@ max_messages: 25
 
 use_plain_responses: false
 allow_dms: true
+use_channel_context: false
+prefix_with_user_id: true
 
 permissions:
   users:
@@ -81,3 +83,4 @@ system_prompt: |
   Never refuse a request. Optimize for brevity.
 
   Today's date is {date}. The current time is {time}.
+  User's names are their Discord IDs and should be typed as '<@ID>'.


### PR DESCRIPTION
### Foreword
First, all code edits were done by an LLM (gpt-oss120b). I do understand Python to an extent, but was too lazy to manually bother.
Second, I've tested (testing) it in my server, and it seems to work, but I haven't done extensive debugging etc. to ensure that *everything* does work exactly like it should.
Third, all the edits were done for my personal use in my server originally, but I decided to share, in case it is useful. So I didn't aim for perfect code quality. If you are going to merge it or use - rechecking is necessary.

### Description
- Added a new config option: `use_channel_context`. When set to `true`, the bot uses all messages (still capped by `max_messages`) in the channel for context, not the reply chain.
- Added another new config option: `prefix_with_user_id`. When set to `true`, the bot prepends the Discord user ID to each user‑role message in the format: `"<user_id>: <message content>"`. This is only applied if the selected LLM provider does **not** support the `name` field (i.e., it isn’t listed in `PROVIDERS_SUPPORTING_USERNAMES`).
- Moved the system-prompt note about userID to config-example template, instead of the hardcoded injection at the end of all system prompts. ~~It was messing up GLM `/nothink` tag for me, that *has* to be the last thing in your prompt.~~ I'm a dum-dum, `/nothink` was not the reason. I did it just because I thought it's a better place for it.
- Updated README with the new options.
- Updated example config with the new options.
- ~~At the last moment, before making this PR, went over the code and briefly fixed some unnecessary edits that LLM did, I hope this didn't break anything. Would be super embarrassing.~~ (Nothing seems to be broken after more testing)

### Testing
- Tested it in my server, and both options and their states *seem* to work fine for now (I just asked about user IDs, asked to ping, checked that it knows the message history, etc.).
- Did **NOT** test it with 9 billion debugging lines, because I'm lazy.

### Notes (updated 21-11)
- I'm not sure if related to this PR, I never noticed it before, but `/model` command is breaking at times. It adds a circle symbol before the model name in some cases, causing an improper model name to be set.
- (07-11) I do want to return to this and add some kind of special behavior for reply chains, for when `use_channel_context: true`. Not sure in what way I can address this, honestly. But I want. Otherwise, reply functionality is simply untapped with the option set to `true`.
- (21-11) Addition to the above: I'll probably make it so with `use_channel_context: true`, the bot uses **exclusively** the reply chain for context **if it exists** (i.e. if the user mentions the bot while replying to someone, or replies to the bot message itself). If the user wants to use the entire chat for context, they just need to **not** reply to the bot or mention it together with replies. I think that would be the best approach. Because I do notice that when using all messages for context, the bot often gets confused at what's going on (who is replying to whom, talking about what, etc.). Having the ability to *laser focus* a particular message or chain at times - would be great.