### PR TITLE
Add Requesty as an OpenAI-compatible provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ llmcord supports remote models from:
 - [Mistral API](https://docs.mistral.ai/getting-started/models/models_overview)
 - [Groq API](https://console.groq.com/docs/models)
 - [OpenRouter API](https://openrouter.ai/models)
+- [Requesty API](https://app.requesty.ai/router)
 
 Or run local models with:
 - [Ollama](https://ollama.com)

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -56,6 +56,10 @@ providers:
     base_url: https://openrouter.ai/api/v1
     api_key: 
 
+  requesty:
+    base_url: https://router.requesty.ai/v1
+    api_key: 
+
   x-ai:
     base_url: https://api.x.ai/v1
     api_key: 


### PR DESCRIPTION
## What

Adds [Requesty](https://requesty.ai) to the list of supported providers. Requesty is an OpenAI-compatible LLM gateway, so it fits the same way the existing `openrouter` provider does: just a `base_url` and an `api_key`.

Changes:
- `config-example.yaml`: new `requesty` provider entry (base_url `https://router.requesty.ai/v1`)
- `README.md`: add Requesty to the supported remote providers list

## Why

llmcord already supports any OpenAI-compatible API, and several users route through gateways. This makes Requesty a one-line config like the other gateways already listed.

## Tested

Verified with the OpenAI SDK against `https://router.requesty.ai/v1` using `provider/model` model names (e.g. `openai/gpt-4o-mini`). Both non-streaming and streaming chat completions work, which matches how llmcord calls the API.

## Disclosure

I work at Requesty. Happy to adjust naming/placement or drop the README line if you'd prefer to keep the list vendor-light. No worries if it's not a fit.